### PR TITLE
removes update flag requirement and just copies / creates new files i…

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,11 @@ then simply run the install script:
 jelly/install
 ```
 
+**NOTE**
+The default files will only be copied / created if they don't already exist.
+Rerunning this command will however rerun `npm install --save-dev`
+
+
 Now you should have access to `dev` task which spins up a instance of [browserSync](https://www.browsersync.io/) at localhost:3000.
 
-Update
--------------
-If you update jelly and there has been changes to the modules in use simply run the update option in the script:
-
-```
-jelly/install.js update
-```
-
-This will not copy over the default files and instead will simply just run npm install with the jelly dev modules.
 

--- a/install.js
+++ b/install.js
@@ -3,41 +3,62 @@
 var configs = require('./gulp/configs');
 var exec = require('child_process').execSync;
 var processOptions = { stdio: 'inherit' };
-var args = process.argv.slice(2, process.argv.length);
+var fs = require('fs');
+
+var copyFile = function (filename, callback) {
+  fs.access(filename, function (err) {
+    if (err) {
+      callback();
+    }
+  });
+};
 
 configs.announce('Installing Jelly!');
 
 configs.announce('Installing Dependencies');
 exec('npm install --save-dev ' + configs.dependencies.join(' '), processOptions);
 
-if (args.indexOf('update') < 0) {
-  configs.announce('Setting up Jelly environment');
+configs.announce('Setting up Jelly environment');
+
+copyFile('./gulpfile.js', function () {
   console.log('Copying over gulpfile.js');
   exec('cp ./jelly/gulp/configs/gulpfile-template.js ./gulpfile.js', processOptions);
+});
 
+copyFile('./tasks/configs/path-builder.js', function () {
   console.log('Creating tasks/configs/path-builder.js');
   exec('mkdir -p ./tasks/configs/', processOptions);
   exec('cp ./jelly/gulp/configs/path-builder-template.js ./tasks/configs/path-builder.js', processOptions);
+});
 
+copyFile('./tasks/configs/webpack/configs.js', function () {
   console.log('Creating webpack configs');
   exec('mkdir -p ./tasks/configs/webpack', processOptions);
   exec('cp ./jelly/gulp/configs/webpack-configs-template.js ./tasks/configs/webpack/configs.js', processOptions);
+});
 
+copyFile('./scripts/index.js', function () {
   console.log('Creating scripts...');
   exec('mkdir -p ./scripts', processOptions);
   exec('touch ./scripts/index.js', processOptions);
+});
 
+copyFile('./styles/main.scss', function () {
   console.log('Creating styles...');
   exec('mkdir -p ./styles', processOptions);
   exec('touch ./styles/main.scss', processOptions);
+});
 
+copyFile('./htmls/index.html', function () {
   console.log('Creating htmls...');
   exec('mkdir -p ./htmls', processOptions);
-  exec('touch ./htmls/index.html', processOptions);
+  exec('cp ./jelly/lib/htmls/index.html ./htmls/index.html', processOptions);
+});
 
+copyFile('.gitignore', function () {
   console.log('Creating gitignore');
   exec('cp ./jelly/gulp/configs/gitignore-template.txt ./.gitignore', processOptions);
-}
+});
 
 configs.announce('May the Jelly be with you!');
 

--- a/lib/htmls/index.html
+++ b/lib/htmls/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title></title>
+  <link rel="stylesheet" href="/styles/main.css">
+</head>
+<body>
+
+</body>
+</html>


### PR DESCRIPTION
`install.js` will not try to open the default files in host repo. If the files exist, do nothing, otherwise copy them over from jelly defaults
